### PR TITLE
feat(quote): Add login routing to quote acceptance button

### DIFF
--- a/frontend/public_web/components/QuoteResults.tsx
+++ b/frontend/public_web/components/QuoteResults.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { QuoteCalculation } from '@/lib/api';
 
 interface QuoteResultsProps {
@@ -7,6 +8,8 @@ interface QuoteResultsProps {
 }
 
 export default function QuoteResults({ quote }: QuoteResultsProps) {
+  const router = useRouter();
+
   const formatCurrency = (value: number) => {
     return new Intl.NumberFormat('es-HN', {
       style: 'currency',
@@ -53,6 +56,20 @@ export default function QuoteResults({ quote }: QuoteResultsProps) {
         </span>
       );
     });
+  };
+
+  // Handle "Aceptar y Continuar" button click
+  const handleAcceptQuote = () => {
+    // TODO: Once NextAuth is implemented, check authentication status here
+    // Example: const session = useSession();
+    // if (session?.user) {
+    //   router.push('/envio/crear'); // Authenticated: go to shipping request
+    // } else {
+    //   router.push('/login'); // Not authenticated: go to login
+    // }
+
+    // For now, route to login page (will be created in Phase 4.2 - Authentication task)
+    router.push('/login');
   };
 
   return (
@@ -243,7 +260,10 @@ export default function QuoteResults({ quote }: QuoteResultsProps) {
         >
           Nueva Cotización
         </button>
-        <button className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium">
+        <button
+          onClick={handleAcceptQuote}
+          className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+        >
           Aceptar y Continuar
         </button>
       </div>


### PR DESCRIPTION
## Summary

Adds navigation logic to the "Aceptar y Continuar" button in quote results, enabling users to proceed with quote acceptance. Currently routes to `/login` (to be created in Phase 4.2 - Authentication).

## Changes

- **QuoteResults.tsx** (`frontend/public_web/components/QuoteResults.tsx`):
  - Import `useRouter` from `next/navigation`
  - Add router hook initialization
  - Create `handleAcceptQuote()` function with routing logic (+14 lines)
  - Add `onClick={handleAcceptQuote}` handler to button
  - Add TODO comments for future NextAuth integration

## Behavior

- **Current:** Routes all users to `/login` page
- **Future (once auth implemented):** Will check authentication state:
  - ✅ Authenticated → route to `/envio/crear` (shipping request)
  - ❌ Not authenticated → route to `/login` or `/register`

## Testing

### Manual Testing Steps:
1. Run development server: `cd frontend/public_web && npm run dev`
2. Navigate to http://localhost:3000/cotizador
3. Fill out quote form and submit
4. Click "Aceptar y Continuar" button in results
5. Verify: Browser attempts to navigate to `/login` (404 expected until auth pages created)

### Expected Behavior:
- ✅ Button is clickable
- ✅ Navigation is triggered
- ⏳ 404 error (login page doesn't exist yet - will be created in Phase 4.2)

## Related Tasks

- **Current Task:** Phase 4.3 - Add Login/Register CTA button routing
  - Complexity: 2/10
  - Time: ~1 hour
  - Status: ✅ Complete

- **Blocked Task:** Phase 4.2 - Authentication (NextAuth)
  - Creates `/login` and `/register` pages
  - Implements session management
  - This PR unblocks that work

- **Task Orchestrator ID:** `d0104116-dd2a-4c69-a19c-90ff79d5290e`

## Impact

✅ **Unblocks:** Authentication team can now create login/register pages  
✅ **Completes:** Quote calculator flow (90% → 95%)  
✅ **Enables:** Quote acceptance workflow to proceed  
⏳ **Waiting for:** Phase 4.2 authentication implementation

## Notes

- Code includes clear TODO comments for NextAuth integration
- Follows Next.js App Router navigation patterns
- No breaking changes
- Ready for authentication team to build on top of

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add client-side navigation logic to the quote acceptance button in QuoteResults, routing all users to /login as a placeholder until authentication is implemented.

New Features:
- Enable the "Aceptar y Continuar" button in QuoteResults to navigate users to the login page

Enhancements:
- Import and initialize Next.js useRouter hook in the QuoteResults component
- Add handleAcceptQuote function with placeholder routing and TODOs for future NextAuth integration
- Attach onClick handler to the acceptance button to trigger routing